### PR TITLE
fix: better handling for non-paginated requests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_DIR: e2e_test
-      GITHUB_PAT: ${{ secrets.GO_GITHUB_PAGINATION_PAT }}
     steps:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:

--- a/e2e_test/demo_test.go
+++ b/e2e_test/demo_test.go
@@ -2,40 +2,22 @@ package e2e_test
 
 import (
 	"context"
-	"fmt"
 	"log"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/gofri/go-github-pagination/github_pagination/github_pagination"
 	"github.com/google/go-github/v58/github"
 )
 
-func tryLoad(key string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
-	}
-	value, err := os.ReadFile(fmt.Sprintf("/tmp/github/%s", key))
-	if err == nil {
-		return strings.TrimSpace(string(value))
-	}
-	return ""
-}
-
 func TestDemo(t *testing.T) {
-	token := tryLoad("GITHUB_PAT")
-	if token == "" {
-		t.Fatal("skipping test, no token provided")
-	}
-
 	pager := github_pagination.NewGithubPaginationClient(nil)
-	gh := github.NewClient(pager).WithAuthToken(token)
+	gh := github.NewClient(pager)
 
 	per_page := 3
 
-	repos, _, err := gh.Repositories.ListByAuthenticatedUser(context.Background(),
-		&github.RepositoryListByAuthenticatedUserOptions{
+	repos, _, err := gh.Repositories.List(context.Background(),
+		"gofri",
+		&github.RepositoryListOptions{
 			ListOptions: github.ListOptions{
 				PerPage: per_page,
 			},
@@ -52,13 +34,8 @@ func TestDemo(t *testing.T) {
 }
 
 func TestNonpagination(t *testing.T) {
-	token := tryLoad("GITHUB_PAT")
-	if token == "" {
-		t.Fatal("skipping test, no token provided")
-	}
-
 	pager := github_pagination.NewGithubPaginationClient(nil)
-	gh := github.NewClient(pager).WithAuthToken(token)
+	gh := github.NewClient(pager)
 
 	issue, _, err := gh.Issues.Get(context.Background(), "gofri", "go-github-pagination", 1)
 	if err != nil {

--- a/e2e_test/demo_test.go
+++ b/e2e_test/demo_test.go
@@ -15,13 +15,12 @@ func TestDemo(t *testing.T) {
 
 	per_page := 3
 
-	repos, _, err := gh.Repositories.List(context.Background(),
+	repos, _, err := gh.Repositories.ListByUser(context.Background(),
 		"gofri",
-		&github.RepositoryListOptions{
+		&github.RepositoryListByUserOptions{
 			ListOptions: github.ListOptions{
 				PerPage: per_page,
 			},
-			Visibility: "public",
 		},
 	)
 	if err != nil {

--- a/e2e_test/demo_test.go
+++ b/e2e_test/demo_test.go
@@ -50,3 +50,21 @@ func TestDemo(t *testing.T) {
 	}
 	log.Printf("found %v repos: \n", len(repos))
 }
+
+func TestNonpagination(t *testing.T) {
+	token := tryLoad("GITHUB_PAT")
+	if token == "" {
+		t.Fatal("skipping test, no token provided")
+	}
+
+	pager := github_pagination.NewGithubPaginationClient(nil)
+	gh := github.NewClient(pager).WithAuthToken(token)
+
+	issue, _, err := gh.Issues.Get(context.Background(), "gofri", "go-github-pagination", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if issue == nil {
+		t.Fatal("expected an issue")
+	}
+}

--- a/github_pagination/json_merger/github_map_combine.go
+++ b/github_pagination/json_merger/github_map_combine.go
@@ -25,8 +25,6 @@ func (g *githubMapCombiner) Digest(reader io.Reader) (slice json.RawMessage, err
 	err = json.NewDecoder(reader).Decode(&result)
 	if err != nil {
 		return nil, fmt.Errorf("failed to digest next map part: %w", err)
-	} else if result.Items == nil {
-		return nil, &NotPaginatableDictError{}
 	}
 
 	g.totalCount += result.TotalCount


### PR DESCRIPTION
- avoid special handling for non-paginated requests (better performance & simplicity).
- delete the messy code from the map merger ❤️
- remove PAT usage from tests (make e2e work on external PRs)

fixes #4 